### PR TITLE
Correct readme (sourceMap option)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ var traceur = require('gulp-traceur');
 
 gulp.task('default', function () {
 	return gulp.src('src/app.js')
-		.pipe(traceur({sourceMaps: true}))
+		.pipe(traceur({sourceMap: true}))
 		.pipe(gulp.dest('dist'));
 });
 ```
@@ -34,7 +34,7 @@ gulp.task('default', function () {
 
 #### options
 
-##### sourceMaps
+##### sourceMap
 
 Type: `boolean`  
 Default: `false`


### PR DESCRIPTION
I'm under the impression that the source map option should be named "sourceMap", see https://github.com/vojtajina/traceur-compiler/blob/master/src/node/api.js#L61
Otherwise it does not work for me.
