### PR TITLE
Add sourceMappingURL comment to generated files

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (options) {
 			ret = traceur.compile(file.contents.toString(), options);
 
 			if (ret.js) {
-				file.contents = new Buffer(ret.js + (ret.SourceMap ? '\n//# sourceMappingURL='+ options.filename + '.map' : ''));
+				file.contents = new Buffer(ret.js + (ret.sourceMap ? '\n//# sourceMappingURL=' + options.filename + '.map' : ''));
 			}
 
 			if (ret.sourceMap) {


### PR DESCRIPTION
Adds a sourceMappingURL comment line in the generated .js files to reference browsers to the generated .map file if sourceMap: true
