### PR TITLE
Fix module names for "register" implementation

### DIFF
--- a/test.js
+++ b/test.js
@@ -48,33 +48,6 @@ it('should expose the Traceur runtime path', function () {
 	assert(typeof traceur.RUNTIME_PATH === 'string');
 	assert(traceur.RUNTIME_PATH.length > 0);
 });
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
-
-it('should support Source Map', function (cb) {
-	var stream = traceur({sourceMap: true});
-
-	var name = 'fixture.js'
-	stream.on('data', function (file) {
-		if (/\.map$/.test(file.path)) {
-			assert(/\"version":3/.test(file.contents.toString()));
-			assert.equal(file.relative, name + '.map');
-			return;
-		}
-
-		assert(new RegExp('sourceMappingURL=' + name + '\.map').test(file.contents.toString()));
-		assert.equal(file.relative, name);
-	})
-
-	stream.on('end', cb);
-
-	stream.write(getFixtureFile(name));
-
-	stream.end();
-});
->>>>>>> Use vynil's relative attribute as module filename
 
 it('should keep folder in module names with cjs modules', function (cb) {
 	// cjs is default module implementation


### PR DESCRIPTION
When compiling with "register" implementation, we found that modules names only contains file names. Ex :

```
src/common/filter.js -> System.register("filter")
```

In contrario, [karma's traceur preprocessor](karma-runner/karma-traceur-preprocessor) produce the expected result:

```
src/common/filter.js -> System.register("src/common/filter")
```

This tiny pull request fix this, without changing the current behaviour of others implementaions ('amd', 'commonjs')
## 

fixes #15 
