### PR TITLE
added option for logErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,20 @@ module.exports = function (options) {
 				applySourceMap(file, ret.generatedSourceMap);
 			}
 		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-traceur', err, {
-				fileName: file.path
-			}));
+			if (options.logErrors) {
+				gutil.log('[gulp-traceur]', err, {fileName: file.path});
+			} else {
+				this.emit('error', new gutil.PluginError('gulp-traceur', err, {
+					fileName: file.path
+				}));
+			}
 		}
 
 		if (ret.errors.length > 0) {
+			if (options.logErrors) {
+				gutil.log('[gulp-traceur]', ret.errors.join('\n'), {fileName: file.path});
+				return cb();
+			}
 			this.emit('error', new gutil.PluginError('gulp-traceur', '\n' + ret.errors.join('\n'), {
 				fileName: file.path,
 				showStack: false


### PR DESCRIPTION
Unless I haven't figured out how to catch errors properly, 
any caught error prevents the task from finishing, so it never re-fires on next file save.  

This is my gulpfile:

``` javascript
gulp.task('es6', function () {
  return gulp.src(paths.server)
    .pipe(changed(paths.build))
    .pipe(traceur(traceurOpts).on('error', handleError))
    .pipe(gulp.dest(paths.build));
});
```

**Adding this option for `logErrors: true` works great.**
