### PR TITLE
Make full path to file visible when error occurs

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function (options) {
 			}
 
 			if (ret.errors.length > 0) {
-				this.emit('error', new gutil.PluginError('gulp-traceur', '\n' + ret.errors.join('\n'), {
+				this.emit('error', new gutil.PluginError('gulp-traceur', ' ' + file.path + ':\n' + ret.errors.join('\n'), {
 					fileName: file.path,
 					showStack: false
 				}));

--- a/test.js
+++ b/test.js
@@ -43,6 +43,18 @@ it('should pass syntax errors', function (cb) {
 	stream.write(getFixtureFile('errored.js'));
 });
 
+it('should include path to file when logging errors', function (cb) {
+	var stream = traceur();
+	var path = new RegExp(__dirname + '/fixture/errored.js');
+
+	stream.on('error', function (err) {
+		assert(path.test(err.message));
+		cb();
+	});
+
+	stream.write(getFixtureFile('errored.js'));
+});
+
 it('should expose the Traceur runtime path', function () {
 	assert(typeof traceur.RUNTIME_PATH === 'string');
 	assert(traceur.RUNTIME_PATH.length > 0);


### PR DESCRIPTION
This makes it easier to sort out where the error is coming from in issues like angular/di.js#63

That would be nice!
