### PR TITLE
Upgrade to traceur 0.0.72.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "vinyl-sourcemaps-apply": "^0.1.1"
   },
   "devDependencies": {
+    "gulp-sourcemaps": "^1.2.8",
     "mocha": "*"
   }
 }


### PR DESCRIPTION
Compile and generate source maps with the new 0.0.72 API.
Added a test to confirm the creation of source maps.
