### PR TITLE
refacto: one compiler ; one sourceMappingURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var objectAssign = require('object-assign');
 var traceur = require('traceur');
 
 module.exports = function (opts) {
-	opts = opts || {};
+
+	var compiler = new traceur.NodeCompiler(objectAssign({modules: 'commonjs'}, opts || {}));
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -19,14 +20,7 @@ module.exports = function (opts) {
 			return;
 		}
 
-		var fileOptions = objectAssign({modules: 'commonjs'}, opts);
-
-		if (file.sourceMap) {
-			fileOptions.sourceMaps = true;
-		}
-
 		try {
-			var compiler = new traceur.NodeCompiler(fileOptions);
 			var ret = compiler.compile(file.contents.toString(), file.relative, file.relative, file.base);
 			var generatedSourceMap = compiler.getSourceMap();
 

--- a/test.js
+++ b/test.js
@@ -45,6 +45,7 @@ it('should generate source maps', function (cb) {
 		var contents = file.contents.toString();
 		assert(/function/.test(contents));
 		assert(/sourceMappingURL=data:application\/json;base64/.test(contents));
+		assert.strictEqual((contents.match(/sourceMappingURL/g) || []).length, 1, 'should be one sourceMappingURL in the content');
 		cb();
 	});
 


### PR DESCRIPTION
- Remove the extra sourceMappingURL.
- Use the same compiler for all the files.

Closes #47 
