### PR TITLE
Added support for experimental and atscript options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ var traceur = require('traceur');
 
 module.exports = function (opts) {
 	var compiler = new traceur.NodeCompiler(objectAssign({modules: 'commonjs'}, opts));
-
+	if (opts.experimental) { compiler.options_.experimental = opts.experimental; }
+	if (opts.atscript) { compiler.options_.experimental = opts.atscript; }
+	
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var traceur = require('traceur');
 module.exports = function (opts) {
 	var compiler = new traceur.NodeCompiler(objectAssign({modules: 'commonjs'}, opts));
 	if (opts.experimental) { compiler.options_.experimental = opts.experimental; }
-	if (opts.atscript) { compiler.options_.experimental = opts.atscript; }
+	if (opts.atscript) { compiler.options_.atscript = opts.atscript; }
 	
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-traceur",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Traceur is a JavaScript.next to JavaScript-of-today compiler",
   "license": "MIT",
   "repository": "sindresorhus/gulp-traceur",


### PR DESCRIPTION
These options do not get automatically set as they are setters in the Traceur object.  All other properties should be extended correctly as they are standard properties.

