### PR TITLE
Relaxed required traceur version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gulp-util": "^3.0.0",
     "object-assign": "^2.0.0",
     "through2": "^0.6.1",
-    "traceur": "0.0.82",
+    "traceur": "~0.0.82",
     "vinyl-sourcemaps-apply": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm unable to update traceur to 0.0.84 (which fixes a nasty bug that affects my codebase), because gulp-traceur hardcodes version to 0.0.82.