### PR TITLE
Add sourceMaps parameter in example usage with sourcemaps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ var concat = require('gulp-concat');
 gulp.task('default', function () {
 	return gulp.src('src/*.js')
 		.pipe(sourcemaps.init())
-		.pipe(traceur())
+		.pipe(traceur({sourceMaps: true}))
 		.pipe(concat('all.js'))
 		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('dist'));


### PR DESCRIPTION
In order for traceur to produce source maps the options "sourceMaps" must be specified.
This change makes it clear in the readme (I lost quite some time to figure out why the produced source maps where not working properly).